### PR TITLE
Update ICBM.java

### DIFF
--- a/src/main/java/com/builtbroken/icbm/ICBM.java
+++ b/src/main/java/com/builtbroken/icbm/ICBM.java
@@ -146,7 +146,7 @@ public final class ICBM extends AbstractMod
 
         // Configs TODO load up using config system, and separate file
         ANTIMATTER_BREAK_UNBREAKABLE = getConfig().getBoolean("Antimatter_Destroy_Unbreakable", Configuration.CATEGORY_GENERAL, true, "Allows antimatter to break blocks that are unbreakable, bedrock for example.");
-        missile_firing_volume = getConfig().getFloat("", "volume", 1.0F, 0, 4, "");
+        missile_firing_volume = getConfig().getFloat("volume", Configuration.CATEGORY_GENERAL, 1.0F, 0, 4, "Missile firing volume");
 
         // Functional Blocks
         blockWarhead = manager.newBlock(TileWarhead.class);


### PR DESCRIPTION
As written, the configuration code produced a section that looked like 

	volume {
		#  [range: 0.0 ~ 4.0, default: 1.0]
		S:=1.0
	}

Strangely enough, Forge can write this configuration but cannot read it. I removed the empty variable name that was giving Forge fits.